### PR TITLE
Generic and Chunk implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
 # fifo
 
-This package implements a fifo queue for strings.
+*Note:* it uses generics so it needs go 1.18 (or current go tip).
 
-It is implemented on a slice. It recycles the slice in case the whole queue resides in the second half of the allocated slice. It also compacts the underlying slice to a smaller one in case the queue is smaller than 1/4 the capacity of the underlying slice.
+This package implements fifo queues:
+
+* `Generic`: big slice generic implementation
+* `String`: non generic version of big slice implementation
+* `Chunk`: chunk storage implementation
+
+`Generic` and `String` are implemented on a slice. It recycles the slice in case the whole queue resides in the second half of the allocated slice. It also compacts the underlying slice to a smaller one in case the queue is smaller than 1/4 the capacity of the underlying slice.
+
+`Chunk` implementation is based on https://github.com/foize/go.fifo. Values are stored in chunks of size 1024. Old chunks are freed when empty after retrieving values.
+
+`Chunk` implementation is faster and consumes less memory. Here are the results from the provided benchmark:
+
+```
+BenchmarkGeneric
+BenchmarkGeneric-16    	       1	1356704075 ns/op	2474543744 B/op	22020262 allocs/op
+BenchmarkString
+BenchmarkString-16     	       1	1392281938 ns/op	2474523512 B/op	22020217 allocs/op
+BenchmarkChunk
+BenchmarkChunk-16      	       2	 778262590 ns/op	748683516 B/op	22041603 allocs/op
+```
 
 ## Usage
 
@@ -12,18 +31,17 @@ Get the module:
 $ go get github.com/jfontan/fifo
 ```
 
-Example:
+Example for `Chunk` implementation:
 
 ```go
 import "github.com/jfontan/fifo"
 
 ...
 
-    s := NewString()
+    s := NewChunk[string]()
 
     s.Push("data")
     v, ok := s.Pop()
     println("Empty?", ok)
     println("Value", v)
 ```
-    

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,65 @@
+package fifo
+
+import "testing"
+
+type Queue interface {
+	Pop() (string, bool)
+	Push(...string)
+}
+
+func BenchmarkGeneric(b *testing.B) {
+	q := New[string]()
+	for n := 0; n < b.N; n++ {
+		benchmark(q)
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	q := NewString()
+	for n := 0; n < b.N; n++ {
+		benchmark(q)
+	}
+}
+
+var benchCases = []struct {
+	counter int
+	add     bool
+}{
+	{
+		counter: 1024 * 1024,
+		add:     true,
+	},
+	{
+		counter: 1024 * 1024,
+		add:     false,
+	},
+	{
+		counter: 10 * 1024 * 1024,
+		add:     true,
+	},
+	{
+		counter: 9 * 1024 * 1024,
+		add:     false,
+	},
+	{
+		counter: 10 * 1024 * 1024,
+		add:     true,
+	},
+	{
+		counter: 9 * 1024 * 1024,
+		add:     false,
+	},
+}
+
+func benchmark(q Queue) {
+	for _, step := range benchCases {
+		for c := 0; c < step.counter; c++ {
+			if step.add {
+				q.Push("string")
+			} else {
+				_, _ = q.Pop()
+			}
+		}
+	}
+
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -2,13 +2,8 @@ package fifo
 
 import "testing"
 
-type Queue interface {
-	Pop() (string, bool)
-	Push(...string)
-}
-
 func BenchmarkGeneric(b *testing.B) {
-	q := New[string]()
+	q := NewGeneric[string]()
 	for n := 0; n < b.N; n++ {
 		benchmark(q)
 	}
@@ -51,7 +46,7 @@ var benchCases = []struct {
 	},
 }
 
-func benchmark(q Queue) {
+func benchmark(q Queue[string]) {
 	for _, step := range benchCases {
 		for c := 0; c < step.counter; c++ {
 			if step.add {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,6 +16,13 @@ func BenchmarkString(b *testing.B) {
 	}
 }
 
+func BenchmarkChunk(b *testing.B) {
+	q := NewChunk[string]()
+	for n := 0; n < b.N; n++ {
+		benchmark(q)
+	}
+}
+
 var benchCases = []struct {
 	counter int
 	add     bool

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,69 @@
+package fifo
+
+const chunkSize = 1024
+
+type chunk[T any] struct {
+	values    [chunkSize]T
+	pos, size int
+	next      *chunk[T]
+}
+
+// Chunk is a fifo queue that stores items in queues.
+type Chunk[T any] struct {
+	head, tail *chunk[T]
+}
+
+var _ Queue[string] = new(Chunk[string])
+
+// NewChunk creates a new Chunk fifo queue.
+func NewChunk[T any]() *Chunk[T] {
+	return new(Chunk[T])
+}
+
+// Empty is true if there are no items in the queue.
+func (c *Chunk[T]) Empty() bool {
+	return c.head == nil || c.head.pos >= c.head.size
+}
+
+// Push adds items to the queue.
+func (c *Chunk[T]) Push(items ...T) {
+	if c.Empty() {
+		var chunk chunk[T]
+		c.head, c.tail = &chunk, &chunk
+	}
+
+	for _, i := range items {
+		c.push(i)
+	}
+}
+
+func (c *Chunk[T]) push(item T) {
+	if c.tail.size >= chunkSize {
+		var chunk chunk[T]
+		c.tail.next = &chunk
+		c.tail = &chunk
+	}
+
+	cur := c.tail
+	cur.values[cur.size] = item
+	cur.size++
+}
+
+// Pop returns the first item in the queue. Also returns false in case the
+// queue is empty.
+func (c *Chunk[T]) Pop() (T, bool) {
+	if c.Empty() {
+		var zero T
+		return zero, false
+	}
+
+	cur := c.head
+	value := cur.values[cur.pos]
+
+	cur.pos++
+	if cur.pos >= cur.size {
+		c.head = cur.next
+	}
+
+	return value, true
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,64 @@
+package fifo
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunk(t *testing.T) {
+	q := NewChunk[string]()
+	testQueue(t, q)
+}
+
+func testQueue(t *testing.T, q Queue[string]) {
+	s := NewGeneric[string]()
+
+	var expected []string
+	var result []string
+
+	for i := 0; i < 1000; i++ {
+		v := strconv.Itoa(i)
+		expected = append(expected, v)
+		s.Push(v)
+	}
+
+	for i := 0; i < 750; i++ {
+		v, ok := s.Pop()
+		require.True(t, ok)
+		result = append(result, v)
+	}
+
+	for i := 0; i < 750; i++ {
+		v := strconv.Itoa(i)
+		expected = append(expected, v)
+		s.Push(v)
+	}
+
+	for {
+		v, ok := s.Pop()
+		if !ok {
+			break
+		}
+		result = append(result, v)
+	}
+
+	// test adding items after emptying the queue
+	for i := 0; i < 256; i++ {
+		v := strconv.Itoa(i)
+		expected = append(expected, v)
+		s.Push(v)
+	}
+
+	for {
+		v, ok := s.Pop()
+		if !ok {
+			break
+		}
+		result = append(result, v)
+	}
+
+	require.Equal(t, expected, result)
+	require.Equal(t, 0, cap(s.items))
+}

--- a/generic.go
+++ b/generic.go
@@ -1,0 +1,67 @@
+package fifo
+
+type FIFO[T any] struct {
+	items []T
+	pos   int
+}
+
+func New[T any]() *FIFO[T] {
+	return new(FIFO[T])
+}
+
+// Push appends new item to the queue.
+func (f *FIFO[T]) Push(v ...T) {
+	f.items = append(f.items, v...)
+}
+
+// Pop return first item in the queue. Also returns false if the queue is
+// empty.
+func (f *FIFO[T]) Pop() (T, bool) {
+	if f.Empty() {
+		var zero T
+		return zero, false
+	}
+
+	item := f.items[f.pos]
+	f.pos++
+
+	f.compact()
+	f.recycle()
+
+	return item, true
+}
+
+// Empty returns true if the queue is empty.
+func (f *FIFO[T]) Empty() bool {
+	return f.pos >= len(f.items)
+}
+
+// recycle moves items to the start of the internal slice if they are all in
+// the second half of the slice.
+func (f *FIFO[T]) recycle() {
+	if f.pos < cap(f.items)/2 {
+		return
+	}
+
+	old := f.items[f.pos:]
+	new := f.items[:len(f.items)-f.pos]
+	copy(new, old)
+
+	f.items = new
+	f.pos = 0
+}
+
+// compact creates a new slice for the data if the queue is smaller that 1/4
+// the capacity of the internal slice.
+func (f *FIFO[T]) compact() {
+	if len(f.items)-f.pos > cap(f.items)/4 {
+		return
+	}
+
+	l := len(f.items) - f.pos
+	new := make([]T, l, l*2)
+	copy(new, f.items[f.pos:])
+
+	f.items = new
+	f.pos = 0
+}

--- a/generic.go
+++ b/generic.go
@@ -1,22 +1,22 @@
 package fifo
 
-type FIFO[T any] struct {
+type Generic[T any] struct {
 	items []T
 	pos   int
 }
 
-func New[T any]() *FIFO[T] {
-	return new(FIFO[T])
+func NewGeneric[T any]() *Generic[T] {
+	return new(Generic[T])
 }
 
 // Push appends new item to the queue.
-func (f *FIFO[T]) Push(v ...T) {
+func (f *Generic[T]) Push(v ...T) {
 	f.items = append(f.items, v...)
 }
 
 // Pop return first item in the queue. Also returns false if the queue is
 // empty.
-func (f *FIFO[T]) Pop() (T, bool) {
+func (f *Generic[T]) Pop() (T, bool) {
 	if f.Empty() {
 		var zero T
 		return zero, false
@@ -32,13 +32,13 @@ func (f *FIFO[T]) Pop() (T, bool) {
 }
 
 // Empty returns true if the queue is empty.
-func (f *FIFO[T]) Empty() bool {
+func (f *Generic[T]) Empty() bool {
 	return f.pos >= len(f.items)
 }
 
 // recycle moves items to the start of the internal slice if they are all in
 // the second half of the slice.
-func (f *FIFO[T]) recycle() {
+func (f *Generic[T]) recycle() {
 	if f.pos < cap(f.items)/2 {
 		return
 	}
@@ -53,7 +53,7 @@ func (f *FIFO[T]) recycle() {
 
 // compact creates a new slice for the data if the queue is smaller that 1/4
 // the capacity of the internal slice.
-func (f *FIFO[T]) compact() {
+func (f *Generic[T]) compact() {
 	if len(f.items)-f.pos > cap(f.items)/4 {
 		return
 	}

--- a/generic_test.go
+++ b/generic_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestString(t *testing.T) {
-	s := NewString()
+func TestFIFO(t *testing.T) {
+	s := New[string]()
 
 	var expected []string
 	var result []string

--- a/generic_test.go
+++ b/generic_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFIFO(t *testing.T) {
-	s := New[string]()
+	s := NewGeneric[string]()
 
 	var expected []string
 	var result []string

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/jfontan/fifo
 
-go 1.16
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,7 @@
+package fifo
+
+type Queue[T any] interface {
+	Pop() (T, bool)
+	Push(...T)
+	Empty() bool
+}


### PR DESCRIPTION
Now it uses generics so it requires go 1.18 or go tip. The new `Chunk` implementation is more performant and uses less memory that the ones based on a big slice.